### PR TITLE
ci: set GOTOOLCHAIN=local

### DIFF
--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CGO_ENABLED: 0
+      GOTOOLCHAIN: local
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -44,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
+      GOTOOLCHAIN: local
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5


### PR DESCRIPTION
Newer versions of the Go toolchain may add a toolchain directive to the go.mod. This causes the Go toolchain to download the specified toolchain for interacting with the module. This silently undermines our CI, which builds and tests against 'stable' and 'oldstable' aliases, respectively.

To fix, set GOTOOLCHAIN=local so it always uses the installed version of Go and does not download the version that is specified by the toolchain directive (when it exists.)

https://go.dev/doc/toolchain#GOTOOLCHAIN