### PR TITLE
add TLS support

### DIFF
--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -37,7 +37,7 @@ jobs:
         go-version: ${{ matrix.toolchain }}
     - uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.60
+        version: v1.64
   test:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ If you have a use-case for any of these things, please file an issue.
 * Old-style option negotation is specifically not supported.
 * `NBD_OPT_PEEK_EXPORT` - The protocol spec describes this as withdrawn and not
 in use.
-* `NBD_OPT_STARTTLS` - This module's Dialer has rudimentary though untested
-support for dialing over TLS.
 * `NBD_CMD_RESIZE` - The protocol spec describes this as defined by an experimental
 `RESIZE` extension.
 * `EXTENDED_HEADER` extension - the initial release of this module is targeting only
@@ -86,6 +84,7 @@ func (c *Conn) Info(name string, requests []InfoRequest) (ExportInfo, error)
 func (c *Conn) List() (exports []string, err error)
 func (c *Conn) ListMetaContext(export string, queries ...string) ([]MetaContext, error)
 func (c *Conn) SetMetaContext(export string, query string, additional ...string) ([]MetaContext, error)
+func (c *Conn) StartTLS(config *tls.Config) error
 func (c *Conn) StructuredReplies() error
 ```
 

--- a/internal/nbdproto/proto.go
+++ b/internal/nbdproto/proto.go
@@ -30,6 +30,7 @@ const (
 	OPT_EXPORT_NAME       uint32 = 1
 	OPT_ABORT             uint32 = 2
 	OPT_LIST              uint32 = 3
+	OPT_STARTTLS          uint32 = 5
 	OPT_INFO              uint32 = 6
 	OPT_GO                uint32 = 7
 	OPT_STRUCTURED_REPLY  uint32 = 8

--- a/nbdkit_test.go
+++ b/nbdkit_test.go
@@ -1,0 +1,70 @@
+package nbd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const megabyte uint64 = 1024 * 1024
+
+var nbdkitBin = func(defaultValue string) string {
+	if v := os.Getenv("NBDKIT"); v != "" {
+		return v
+	}
+	return defaultValue
+}("nbdkit")
+
+func provideNBDUnix(name string, size uint64) (wait func(), err error) {
+	return nbdkitUnix(name, size)
+}
+
+func nbdkitUnix(name string, size uint64) (wait func(), err error) {
+	args := []string{
+		"--exit-with-parent",
+		"-U",
+		name,
+		"memory",
+		fmt.Sprintf("%dM", size/megabyte),
+	}
+
+	wait, err = nbdkit(args)
+	if err != nil {
+		return wait, err
+	}
+
+	for {
+		_, err := os.Stat(name)
+		if err == nil {
+			break
+		}
+		if os.IsNotExist(err) {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+	}
+
+	return wait, nil
+}
+
+func nbdkit(args []string) (wait func(), err error) {
+	wait = func() {}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = cancel // Just to appease the 'lostcancel' lint failure
+
+	cmd := exec.CommandContext(ctx, nbdkitBin, args...)
+	err = cmd.Start()
+	if err != nil {
+		return wait, fmt.Errorf("start nbdkit %v: %w", args, err)
+	}
+
+	wait = func() {
+		cancel()
+		_ = cmd.Wait()
+	}
+
+	return wait, nil
+}

--- a/nbdkit_test.go
+++ b/nbdkit_test.go
@@ -2,9 +2,15 @@ package nbd
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"testing"
 	"time"
 )
 
@@ -17,11 +23,56 @@ var nbdkitBin = func(defaultValue string) string {
 	return defaultValue
 }("nbdkit")
 
-func provideNBDUnix(name string, size uint64) (wait func(), err error) {
-	return nbdkitUnix(name, size)
+func provideNBDUnix(t *testing.T, name string, size uint64) (wait func(), err error) {
+	return nbdkitUnix(t, name, size)
 }
 
-func nbdkitUnix(name string, size uint64) (wait func(), err error) {
+func provideSecureNBDUnix(t *testing.T, name string, size uint64, pkiDir string) (tlsConf *tls.Config, wait func(), err error) {
+	wait = func() {}
+
+	ca, capriv, err := newTestCACertAndKey()
+	if err != nil {
+		return nil, wait, err
+	}
+
+	caCert, err := x509.ParseCertificate(ca)
+	if err != nil {
+		return nil, wait, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	server, serverpriv, err := newServerCertAndKey(caCert, capriv)
+	if err != nil {
+		return nil, wait, err
+	}
+
+	err = nbdkitWritePKI(pkiDir, ca, server, serverpriv)
+	if err != nil {
+		return nil, wait, err
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(caCert)
+
+	tlsConf = &tls.Config{
+		RootCAs:            certPool,
+		InsecureSkipVerify: true,
+	}
+
+	extra := []string{
+		"--tls=require",
+		"--tls-certificates",
+		pkiDir,
+	}
+
+	wait, err = nbdkitUnix(t, name, size, extra...)
+	if err != nil {
+		return nil, wait, err
+	}
+
+	return tlsConf, wait, nil
+}
+
+func nbdkitUnix(t *testing.T, name string, size uint64, extra ...string) (wait func(), err error) {
 	args := []string{
 		"--exit-with-parent",
 		"-U",
@@ -30,7 +81,7 @@ func nbdkitUnix(name string, size uint64) (wait func(), err error) {
 		fmt.Sprintf("%dM", size/megabyte),
 	}
 
-	wait, err = nbdkit(args)
+	wait, err = nbdkit(t, append(extra, args...))
 	if err != nil {
 		return wait, err
 	}
@@ -49,13 +100,15 @@ func nbdkitUnix(name string, size uint64) (wait func(), err error) {
 	return wait, nil
 }
 
-func nbdkit(args []string) (wait func(), err error) {
+func nbdkit(t *testing.T, args []string) (wait func(), err error) {
 	wait = func() {}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	_ = cancel // Just to appease the 'lostcancel' lint failure
 
+	t.Logf("%v", append([]string{nbdkitBin}, args...))
 	cmd := exec.CommandContext(ctx, nbdkitBin, args...)
+
 	err = cmd.Start()
 	if err != nil {
 		return wait, fmt.Errorf("start nbdkit %v: %w", args, err)
@@ -63,8 +116,50 @@ func nbdkit(args []string) (wait func(), err error) {
 
 	wait = func() {
 		cancel()
-		_ = cmd.Wait()
+		err = cmd.Wait()
+		t.Log("stdout", cmd.Stdout)
+		t.Log("stderr", cmd.Stderr)
 	}
 
 	return wait, nil
+}
+
+func nbdkitWritePKI(
+	dir string,
+	caDER []byte,
+	serverDER []byte,
+	privkey *rsa.PrivateKey,
+) error {
+	// from man page: nbdkit-tls(1), these are the expected
+	// filenames under the directory given to nbdkit via
+	// --tls-certificates.
+	blocks := map[string]*pem.Block{
+		"ca-cert.pem": {
+			Type:  "CERTIFICATE",
+			Bytes: caDER,
+		},
+		"server-cert.pem": {
+			Type:  "CERTIFICATE",
+			Bytes: serverDER,
+		},
+		"server-key.pem": {
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privkey),
+		},
+	}
+
+	for filename, block := range blocks {
+		f, err := os.Create(filepath.Join(dir, filename))
+		if err != nil {
+			return fmt.Errorf("create %s: %w", filename, err)
+		}
+		defer f.Close()
+
+		err = pem.Encode(f, block)
+		if err != nil {
+			return fmt.Errorf("write PEM block to %s: %v", filename, err)
+		}
+	}
+
+	return nil
 }

--- a/negotiation.go
+++ b/negotiation.go
@@ -111,6 +111,12 @@ func (i *infoGoRequest) Serialize(buf *bytes.Buffer) error {
 	return nil
 }
 
+type startTLSRequest struct {
+	empty
+}
+
+func (*startTLSRequest) ID() uint32 { return nbdproto.OPT_STARTTLS }
+
 type infoRequest struct {
 	infoGoRequest
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,84 @@
+package nbd
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+func newTestCACertAndKey() ([]byte, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA private key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Hour)
+
+	usage := x509.KeyUsageDigitalSignature |
+		x509.KeyUsageKeyAgreement |
+		x509.KeyUsageKeyEncipherment |
+		x509.KeyUsageDataEncipherment
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(0),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		KeyUsage:              usage,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create CA cert: %w", err)
+	}
+
+	return caBytes, key, nil
+}
+
+func newServerCertAndKey(caCert *x509.Certificate, caKey crypto.Signer) ([]byte, *rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate server private key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Hour)
+
+	usage := x509.KeyUsageDigitalSignature |
+		x509.KeyUsageKeyAgreement |
+		x509.KeyUsageKeyEncipherment |
+		x509.KeyUsageDataEncipherment
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(0),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		KeyUsage:              usage,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+
+	serverBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create server cert: %w", err)
+	}
+
+	return serverBytes, key, nil
+}


### PR DESCRIPTION
When adding additional integration tests around dialing over TLS I
learned that the original implementation just simply never ever worked.

The NBD server state machine still expects to begin option negotiation
outside of TLS, one of which must be OPT_STARTTLS in order to upgrade
the existing connection to a secure one, rather than expecting a TLS
handshake and then engaging in option negotation.

I've added support for NBD_OPT_STARTTLS along with a corresponding
integration test.