### PR TITLE
{nbdkit,tls}_test.go: add missing SPDX headers

### DIFF
--- a/nbdkit_test.go
+++ b/nbdkit_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package nbd
 
 import (

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package nbd
 
 import (


### PR DESCRIPTION
Forgot to add these in a previous pull request.