### PR TITLE
ci: upgrade golangci-lint-action to v7.0.0

### DIFF
--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -35,9 +35,9 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.toolchain }}
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v1.64
+        version: v2.0.2
   test:
     strategy:
       matrix:

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -25,12 +25,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("nbd dial: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	err = conn.Connect()
 	if err != nil {
 		return fmt.Errorf("nbd connect: %w", err)
 	}
-	defer conn.Abort()
+	defer func() { _ = conn.Abort() }()
 	exports, err := conn.List()
 	if err != nil {
 		return fmt.Errorf("nbd list: %w", err)
@@ -64,7 +64,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("nbd: export name: %w", err)
 	}
-	defer conn.Disconnect()
+	defer func() { _ = conn.Disconnect() }()
 
 	// Note, you'll want to do something smarter for the length
 	// field if your export is larger than math.MaxUint32.

--- a/nbdkit_test.go
+++ b/nbdkit_test.go
@@ -155,7 +155,7 @@ func nbdkitWritePKI(
 		if err != nil {
 			return fmt.Errorf("create %s: %w", filename, err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		err = pem.Encode(f, block)
 		if err != nil {


### PR DESCRIPTION
Resolves the following lint errors:

```
[error]examples/client/main.go:28:18: Error return value of `conn.Close` is not checked (errcheck)
      defer conn.Close()
                      ^
[error]examples/client/main.go:33:18: Error return value of `conn.Abort` is not checked (errcheck)
      defer conn.Abort()
                      ^
[error]examples/client/main.go:67:23: Error return value of `conn.Disconnect` is not checked (errcheck)
      defer conn.Disconnect()
                           ^
[error]nbdkit_test.go:262:16: Error return value of `f.Close` is not checked (errcheck)
      	defer f.Close()
      	             ^
[error]conn.go:485:4: QF1003: could use tagged switch on r.structured.Type (staticcheck)
			if r.structured.Type == nbdproto.REPLY_TYPE_OFFSET_DATA {
			^
5 issues:
* errcheck: 4
* staticcheck: 1
```

While in there, prefer the commit SHA as an immutable reference to the release, since tags are just pointers that can be changed.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions