### PR TITLE
upgrade golangci-lint from v2.0.2 to v2.1

### DIFF
--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -37,7 +37,7 @@ jobs:
         go-version: ${{ matrix.toolchain }}
     - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v2.0.2
+        version: v2.1
   test:
     strategy:
       matrix:


### PR DESCRIPTION
To unblock Dependabot's PR where it upgrades golangci-lint-action.