### PR TITLE
introduce internal buffer for message (de)serialization

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nbd
+
+import (
+	"testing"
+
+	"github.com/digitalocean/go-nbd/internal/nbdproto"
+)
+
+func TestDefaultBufferSizeFitsMaxNBDStringLength(t *testing.T) {
+	if DefaultBufferSize < nbdproto.MaximumStringLength {
+		t.Errorf("DefaultBufferSize should be >= %d",
+			nbdproto.MaximumStringLength)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -3,6 +3,7 @@
 package nbd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/digitalocean/go-nbd/internal/nbdproto"
@@ -124,3 +125,5 @@ type NullOffset struct {
 	Value uint64
 	Valid bool
 }
+
+var errPayloadTooLarge = errors.New("payload size exceeds internal buffer")

--- a/internal/nbdproto/proto.go
+++ b/internal/nbdproto/proto.go
@@ -89,6 +89,8 @@ const (
 	ESHUTDOWN uint32 = 108
 )
 
+const MaximumStringLength = 4096
+
 type NegotiationHeader struct {
 	Magic   uint64
 	Version uint64


### PR DESCRIPTION
This will help us move memory allocations into the control of client
code. Let's start with reading option replies and subsequent patches
will lift and shift the other code paths onto using it for transmission,
etc.

Reported-by: m01e (memory allocation denial-of-service)