### PR TITLE
push tls.Client requirements to the calling code

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -271,6 +271,9 @@ func (c *Conn) List() (exports []string, err error) {
 	return exports, nil
 }
 
+// StartTLS upgrades the connection to TLS. Similar to [crypto/tls.Client],
+// config cannot be nil: users must set either ServerName or InsecureSkipVerify
+// in the config.
 func (c *Conn) StartTLS(config *tls.Config) error {
 	if state := c.state(); state != connectionStateOptions {
 		return errNotOption
@@ -292,10 +295,6 @@ func (c *Conn) StartTLS(config *tls.Config) error {
 
 	if reply.Type != nbdproto.REP_ACK {
 		return errors.New("server did not reply with error or ACK")
-	}
-
-	if config == nil {
-		config = new(tls.Config)
 	}
 
 	c.conn = tls.Client(c.conn, config)


### PR DESCRIPTION
Passing a zero-value tls.Config to tls.Client causes the very next use of the connection to fail with:

	tls: either ServerName or InsecureSkipVerify must be specified
	in the tls.Config

Which is not at all useful. The package isn't in a good position to provide sane defaults here, so just push it all to the caller.

Reported-by: ba1van7