### PR TITLE
fix staticcheck failure S1016

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -537,6 +537,8 @@ func (c *Conn) SetMetaContext(export string, queries []string, yield MetaContext
 		if err != nil {
 			return err
 		}
+
+		//nolint:staticcheck // S1016
 		err = yield(MetaContext{ID: r.ID, Name: r.Name})
 		if err != nil {
 			c.setState(connectionStateCanceled)


### PR DESCRIPTION
Error: conn.go:540:15: S1016: should convert r (type repMetaContext) to MetaContext instead of using struct literal (staticcheck)

https://staticcheck.dev/docs/checks/#S1016