### PR TITLE
use version of golangci-lint that supports go1.26

### DIFF
--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -37,7 +37,7 @@ jobs:
         go-version: ${{ matrix.toolchain }}
     - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.1
+        version: v2.9
   test:
     strategy:
       matrix:

--- a/.github/workflows/go-nbd.yaml
+++ b/.github/workflows/go-nbd.yaml
@@ -55,3 +55,4 @@ jobs:
       run: sudo apt-get install nbdkit
     - name: Test
       run: go test -timeout 1m -v ./...
+


### PR DESCRIPTION
The go "stable" alias in the CI pipeline has changed to 1.26 which is
causing golangci-lint to panic in workflows.