### PR TITLE
remove Conn's inTransmission field

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -130,9 +130,8 @@ type Conn struct {
 	discardZeroes bool
 	structured    bool
 
-	state_         atomic.Int32
-	inTransmission atomic.Bool
-	cookie         atomic.Uint64
+	state_ atomic.Int32
+	cookie atomic.Uint64
 
 	buflk chan struct{}
 	buf   []byte
@@ -223,7 +222,7 @@ func (c *Conn) ExportName(name string) (size uint64, flags TransmissionFlags, er
 }
 
 func (c *Conn) Abort() error {
-	if c.inTransmission.Load() {
+	if state := c.state(); state != connectionStateOptions {
 		return nil
 	}
 	err := requestOption(c.conn, &abortRequest{})
@@ -920,10 +919,13 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 }
 
 func (c *Conn) Disconnect() error {
-	if state := c.state(); state == connectionStateError {
+	state := c.state()
+
+	if state == connectionStateError {
 		return nil
 	}
-	if !c.inTransmission.Load() {
+
+	if state != connectionStateTransmission {
 		return errNotTransmission
 	}
 
@@ -946,7 +948,6 @@ func (c *Conn) setState(s connectionState) {
 }
 
 func (c *Conn) enterTransmission() {
-	c.inTransmission.Store(true)
 	c.setState(connectionStateTransmission)
 }
 


### PR DESCRIPTION
It's made redundant by the state enum. This also strengthens
Conn.Disconnect since before it was possible to call it twice because
the inTransmission field would stay on even when the Conn transitioned
to a different state.

So if it was an a state that wasn't the error state, it would pass the
inTransmission check and send another CMD_DISC.