### PR TITLE
reject structured replies if they have not been negotiated

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -575,7 +575,9 @@ func (c *Conn) Read(buf []byte, offset uint64, flags CommandFlags) (n int, err e
 	var coveredRegions []span.Span[uint64]
 
 	for {
-		var hdr transmissionHeader
+		hdr := transmissionHeader{
+			structuredReplies: c.structured,
+		}
 		err = hdr.DecodeFrom(c.conn)
 		if err != nil {
 			return n, err
@@ -700,7 +702,7 @@ func (c *Conn) Write(data []byte, offset uint64, flags CommandFlags) error {
 
 	length := uint32(len(data))
 
-	return oneShotTransmit(c.conn, uint16(flags), nbdproto.CMD_WRITE, cookie, offset, length, data, buf)
+	return c.oneShotTransmit(uint16(flags), nbdproto.CMD_WRITE, cookie, offset, length, data, buf)
 }
 
 func (c *Conn) Flush(flags CommandFlags) error {
@@ -714,7 +716,7 @@ func (c *Conn) Flush(flags CommandFlags) error {
 
 	cookie := c.cookie.Add(1)
 
-	return oneShotTransmit(c.conn, uint16(flags), nbdproto.CMD_FLUSH, cookie, 0, 0, nil, buf)
+	return c.oneShotTransmit(uint16(flags), nbdproto.CMD_FLUSH, cookie, 0, 0, nil, buf)
 }
 
 func (c *Conn) Trim(offset uint64, length uint32, flags CommandFlags) error {
@@ -728,7 +730,7 @@ func (c *Conn) Trim(offset uint64, length uint32, flags CommandFlags) error {
 
 	cookie := c.cookie.Add(1)
 
-	return oneShotTransmit(c.conn, uint16(flags), nbdproto.CMD_TRIM, cookie, offset, length, nil, buf)
+	return c.oneShotTransmit(uint16(flags), nbdproto.CMD_TRIM, cookie, offset, length, nil, buf)
 }
 
 func (c *Conn) Cache(offset uint64, length uint32, flags CommandFlags) error {
@@ -742,7 +744,7 @@ func (c *Conn) Cache(offset uint64, length uint32, flags CommandFlags) error {
 
 	cookie := c.cookie.Add(1)
 
-	return oneShotTransmit(c.conn, uint16(flags), nbdproto.CMD_CACHE, cookie, offset, length, nil, buf)
+	return c.oneShotTransmit(uint16(flags), nbdproto.CMD_CACHE, cookie, offset, length, nil, buf)
 }
 
 func (c *Conn) WriteZeroes(offset uint64, length uint32, flags CommandFlags) error {
@@ -756,7 +758,7 @@ func (c *Conn) WriteZeroes(offset uint64, length uint32, flags CommandFlags) err
 
 	cookie := c.cookie.Add(1)
 
-	return oneShotTransmit(c.conn, uint16(flags), nbdproto.CMD_WRITE_ZEROES, cookie, offset, length, nil, buf)
+	return c.oneShotTransmit(uint16(flags), nbdproto.CMD_WRITE_ZEROES, cookie, offset, length, nil, buf)
 }
 
 // BlockStatusFunc is a push-based iterator for consuming the stream of
@@ -798,7 +800,9 @@ func (c *Conn) BlockStatus(offset uint64, length uint32, yield BlockStatusFunc, 
 	}
 
 	for {
-		var hdr transmissionHeader
+		hdr := transmissionHeader{
+			structuredReplies: c.structured,
+		}
 		err = hdr.DecodeFrom(c.conn)
 		if err != nil {
 			return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -41,9 +41,10 @@ func newTestConn(response []byte) *Conn {
 	buflk <- struct{}{}
 
 	conn := &Conn{
-		conn:  &mockConn{r: bytes.NewReader(response), w: io.Discard},
-		buflk: buflk,
-		buf:   make([]byte, DefaultBufferSize),
+		conn:       &mockConn{r: bytes.NewReader(response), w: io.Discard},
+		buflk:      buflk,
+		buf:        make([]byte, DefaultBufferSize),
+		structured: true,
 	}
 	conn.state_.Store(int32(connectionStateTransmission))
 	// cookie starts at 0; Read will Add(1) to get 1 as the first cookie

--- a/transmission.go
+++ b/transmission.go
@@ -104,6 +104,8 @@ type BlockStatusDescriptor struct {
 type transmissionHeader struct {
 	simple     *nbdproto.SimpleReplyHeader
 	structured *nbdproto.StructuredReplyHeader
+
+	structuredReplies bool
 }
 
 func (t *transmissionHeader) DecodeFrom(r io.Reader) error {
@@ -114,6 +116,11 @@ func (t *transmissionHeader) DecodeFrom(r io.Reader) error {
 	if magic != nbdproto.NBD_SIMPLE_REPLY_MAGIC && magic != nbdproto.NBD_STRUCTURED_REPLY_MAGIC {
 		return fmt.Errorf("got invalid magic %x", magic)
 	}
+
+	if !t.structuredReplies && magic == nbdproto.NBD_STRUCTURED_REPLY_MAGIC {
+		return fmt.Errorf("got unnegotiated NBD_STRUCTURED_REPLY_MAGIC")
+	}
+
 	if magic == nbdproto.NBD_SIMPLE_REPLY_MAGIC {
 		hdr := nbdproto.SimpleReplyHeader{
 			Magic: magic,
@@ -161,8 +168,7 @@ func (t *transmissionHeader) IsErr() bool {
 	return false
 }
 
-func oneShotTransmit(
-	server io.ReadWriter,
+func (c *Conn) oneShotTransmit(
 	cflags uint16,
 	type_ uint16,
 	cookie uint64,
@@ -171,13 +177,15 @@ func oneShotTransmit(
 	payload []byte,
 	buf []byte,
 ) error {
-	err := requestTransmit(server, cflags, type_, cookie, offset, length, payload)
+	err := requestTransmit(c.conn, cflags, type_, cookie, offset, length, payload)
 	if err != nil {
 		return err
 	}
 
-	var hdr transmissionHeader
-	err = hdr.DecodeFrom(server)
+	hdr := transmissionHeader{
+		structuredReplies: c.structured,
+	}
+	err = hdr.DecodeFrom(c.conn)
 	if err != nil {
 		return err
 	}
@@ -201,7 +209,7 @@ func oneShotTransmit(
 		d := transmissionErrorDecoder{
 			hdr: hdr,
 			buf: buf,
-			r:   server,
+			r:   c.conn,
 		}
 		if err := d.Decode(&terr); err != nil {
 			return err

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package nbd
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/digitalocean/go-nbd/internal/nbdproto"
+)
+
+func Test_transmissionHeader_DecodeFrom_UnnegotiatedStructuredReplies(t *testing.T) {
+	var buf bytes.Buffer
+	err := binary.Write(&buf, binary.BigEndian, nbdproto.NBD_STRUCTURED_REPLY_MAGIC)
+	if err != nil {
+		t.Fatalf("set up input buffer: %v", err)
+	}
+
+	hdr := transmissionHeader{
+		structuredReplies: false,
+	}
+
+	var errString string
+	err = hdr.DecodeFrom(&buf)
+	if err != nil {
+		errString = err.Error()
+	}
+
+	want := "got unnegotiated NBD_STRUCTURED_REPLY_MAGIC"
+	if errString != want {
+		t.Errorf("got %q, want %q", errString, want)
+	}
+}


### PR DESCRIPTION
The specification states:

	> The simple reply message MUST be sent by the server in response to
	> all requests if structured replies have not been negotiated using
	> NBD_OPT_STRUCTURED_REPLY.