### PR TITLE
zero out holes during read

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -646,6 +646,11 @@ func (c *Conn) Read(buf []byte, offset uint64, flags CommandFlags) (n int, err e
 			}
 			coveredRegions = append(coveredRegions, got)
 
+			start := hole.Offset - offset
+			end := start + uint64(hole.Length)
+
+			clear(buf[start:end])
+
 			n += int(hole.Length)
 		case nbdproto.REPLY_TYPE_OFFSET_DATA:
 			var absoluteOffset uint64


### PR DESCRIPTION
Otherwise, we risk incorrectly leaving garbage in areas where there
should be zeroes for callers that are reusing the given buf for multiple
Read calls. Reusing the buf is the expected behavior, so let's zero out
holes accordingly.